### PR TITLE
Feat: Add Helm chart for FCG.Jogos.API and update Dockerfile

### DIFF
--- a/FCG.Jogos.API/Dockerfile
+++ b/FCG.Jogos.API/Dockerfile
@@ -1,39 +1,33 @@
 # syntax=docker/dockerfile:1
 
-# Runtime image
+# Imagem base para runtime
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 WORKDIR /app
-# Expose HTTP only; see note in README about HTTPS redirection in Program.cs
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
 
-# Build image
+# Imagem para build
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /src
 
-# Copy solution and project files for better layer caching
+# Copia apenas os arquivos de projeto e solução para cache de dependências
 COPY FCG.Jogos.sln ./
 COPY FCG.Jogos.API/FCG.Jogos.API.csproj FCG.Jogos.API/
 COPY FCG.Jogos.Application/FCG.Jogos.Application.csproj FCG.Jogos.Application/
 COPY FCG.Jogos.Domain/FCG.Jogos.Domain.csproj FCG.Jogos.Domain/
 COPY FCG.Jogos.Infrastructure/FCG.Jogos.Infrastructure.csproj FCG.Jogos.Infrastructure/
 
-# Restore dependencies
+# Restaura dependências
 RUN dotnet restore FCG.Jogos.API/FCG.Jogos.API.csproj
 
-# Copy the rest of the source
+# Copia o restante do código
 COPY . .
-WORKDIR /src/FCG.Jogos.API
 
-# Build
-RUN dotnet build -c Release -o /app/build
+# Publica a aplicação
+RUN dotnet publish FCG.Jogos.API/FCG.Jogos.API.csproj -c Release -o /app/publish /p:UseAppHost=false
 
-# Publish
-FROM build AS publish
-RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
-
-# Final runtime image
+# Imagem final
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app/publish .
+COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "FCG.Jogos.API.dll"]

--- a/helm/fcg-jogos-api/Chart.yaml
+++ b/helm/fcg-jogos-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: fcg-jogos-api
+version: 0.1.0
+description: Helm chart for deploying FCG.Jogos.API (.NET 8)
+type: application

--- a/helm/fcg-jogos-api/templates/_helpers.tpl
+++ b/helm/fcg-jogos-api/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "fcg-jogos-api.name" -}}
+fcg-jogos-api
+{{- end -}}
+
+{{- define "fcg-jogos-api.fullname" -}}
+{{ .Release.Name }}-{{ include "fcg-jogos-api.name" . }}
+{{- end -}}

--- a/helm/fcg-jogos-api/templates/configmap.yaml
+++ b/helm/fcg-jogos-api/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.configmap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fcg-jogos-api.fullname" . }}-config
+  labels:
+    app: {{ include "fcg-jogos-api.name" . }}
+data:
+{{- range $key, $value := .Values.configmap.data }}
+  {{ $key }}: "{{ $value }}"
+{{- end }}
+{{- end }}

--- a/helm/fcg-jogos-api/templates/deployment.yaml
+++ b/helm/fcg-jogos-api/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fcg-jogos-api.fullname" . }}
+  labels:
+    app: {{ include "fcg-jogos-api.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "fcg-jogos-api.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "fcg-jogos-api.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "fcg-jogos-api.fullname" . }}-config
+            - secretRef:
+                name: {{ include "fcg-jogos-api.fullname" . }}-secret

--- a/helm/fcg-jogos-api/templates/hpa.yaml
+++ b/helm/fcg-jogos-api/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fcg-jogos-api.fullname" . }}
+  labels:
+    app: {{ include "fcg-jogos-api.name" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fcg-jogos-api.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/fcg-jogos-api/templates/secret.yaml
+++ b/helm/fcg-jogos-api/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fcg-jogos-api.fullname" . }}-secret
+  labels:
+    app: {{ include "fcg-jogos-api.name" . }}
+type: Opaque
+data:
+{{- range $key, $value := .Values.secret.data }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/helm/fcg-jogos-api/templates/service.yaml
+++ b/helm/fcg-jogos-api/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fcg-jogos-api.fullname" . }}
+  labels:
+    app: {{ include "fcg-jogos-api.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+  selector:
+    app: {{ include "fcg-jogos-api.name" . }}

--- a/helm/fcg-jogos-api/values.yaml
+++ b/helm/fcg-jogos-api/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+image:
+  repository: fabriciorosanet/fcg-jogos-api
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+configmap:
+  enabled: true
+  data:
+    ASPNETCORE_ENVIRONMENT: "Production"
+    CUSTOM_CONFIG: "value"
+secret:
+  enabled: true
+  data:
+    ConnectionStrings__DefaultConnection: "Host=aws-1-us-east-2.pooler.supabase.com;Port=5432;Database=postgres;Username=postgres.elcvczlnnzbgcpsbowkg;Password=Fiap@1234;Ssl Mode=Require;Trust Server Certificate=true;"


### PR DESCRIPTION
Introduced a Helm chart for deploying FCG.Jogos.API, including templates for deployment, service, configmap, secret, and HPA, along with default values. The Dockerfile was streamlined and updated with improved build and publish steps, and comments were translated to Portuguese.